### PR TITLE
Add ookla-http to readme and a fallback to regular ookla

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Usage: traceneck [OPTIONS]
 
 Options:
   -I, --interface string   Interface (default "enp0s31f6")
-  -t, --tool string        Speedtest tool to use: ndt or ookla (default "ndt")
+  -t, --tool string        Speedtest tool to use: ndt or ookla or ookla-http (default "ndt")
   -s, --server string      IP address and port (<ip>:<port>) for custom server. Optional. If not provided, will use default server.
   -n, --no-ping            Skip pings
   -p, --ping-type string   Ping packet type: icmp or udp (default "icmp")

--- a/internal/network/client.go
+++ b/internal/network/client.go
@@ -33,13 +33,17 @@ func SpeedtestProcess() {
 		cmd = exec.Command("speedtest", cmdArgs...)
 		logParser = logParserOokla
 	case "ookla-http":
-		cmdArgs := []string{"--json", "--server-ip", config.Server}
-		if config.Server == ""{
-			cmdArgs = append(cmdArgs,"127.0.0.1:80")
+		var cmdArgs []string
+		if config.Server == "" {
+			log.Println("[ookla-http] No server specified, falling back to regular ookla.")
+			cmdArgs = []string{"--accept-license", "-f", "json", "-p", "yes"}
+			cmd = exec.Command("speedtest", cmdArgs...)
+			logParser = logParserOokla
+		} else {
+			cmdArgs = []string{"--json", "--server-ip", config.Server}
+			cmd = exec.Command("tools/ookla-http/speedtest.py", cmdArgs...)
+			logParser = logParserOoklaHttp
 		}
-		cmd = exec.Command("tools/ookla-http/speedtest.py", cmdArgs...)
-		logParser = logParserOoklaHttp
-
 	case "iperf":
 		cmdArgs := []string{"-c", config.Server, "-J"}
 		if config.Server == "" {


### PR DESCRIPTION
# Changes in this PR:
- Updated README to include the new tool.
- Added fallback to default Ookla if `--server` is not provided.